### PR TITLE
Minimal GitHub Action to build and push Docker image stephaneklein/pg_back-docker-sidecar

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,25 @@
+name: Build and Push Docker Image
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  docker_build_push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: stephaneklein
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and Push Docker Image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: stephaneklein/pg_back-docker-sidecar:latest


### PR DESCRIPTION
Closes #8

Here is a minimalist first iteration of a GitHub Action to automatically build and push the Docker image `stephaneklein/pg_back-docker-sidecar`.

It is possible to improve this Action, but I prefer to merge this version right away and improve it as I go along.

See this success job execution: https://github.com/stephane-klein/pg_back-docker-sidecar/actions/runs/15531402531/job/43720971213