### PR TITLE
Add support for PostgreSQL versions 15, 16 and 17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,10 +21,15 @@ RUN cd pg_back && CGO_ENABLED=0 go build -ldflags="-w -s" -o /go/bin/pg_back
 
 FROM --platform=$BUILDPLATFORM alpine:3.21
 
+# pg_back need pg_dump, then PostgreSQL client packages are installed
+# Multiple PostgreSQL versions are provided because for example a backup
+# made with Postgres17 cannot be restored on an instance running version 16
 RUN apk add --no-cache \
     bash=5.2.37-r0 \
     gomplate=4.2.0-r5 \
-    postgresql17-client=17.5-r0 # pg_back need pg_dump, then PostgreSQL version 17.5 is installed
+    postgresql17-client=17.5-r0 \
+    postgresql16-client=16.9-r0 \
+    postgresql15-client=15.13-r0
 
 COPY --from=build-stage --chmod=0755 /tmp/supercronic /usr/local/bin/supercronic
 COPY --from=build-stage --chmod=0755 /go/bin/pg_back /usr/local/bin/pg_back
@@ -32,6 +37,7 @@ COPY --from=build-stage --chmod=0755 /go/bin/pg_back /usr/local/bin/pg_back
 COPY ./pg_back.conf.tmpl /pg_back.conf.tmpl
 COPY --chmod=0755 ./entrypoint.sh /entrypoint.sh
 
+ENV POSTGRES_VERSION=17
 ENV POSTGRES_HOST="postres"
 ENV POSTGRES_PORT="5432"
 ENV POSTGRES_USER="postgres"

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Here's an example of a `docker-compose.yml` for using `pg_back-docker-sidecar` i
 
 For more information about the role and usage of `pg_back-docker-sidecar` environment variables, you can consult the content of the [`pg_back.conf.tmpl`](https://github.com/stephane-klein/pg_back-docker-sidecar/blob/main/pg_back.conf.tmpl) file.
 
+You can select the PostgreSQL version that will be used by *pg_back* by specifying the version number in the `POSTGRES_VERSION` environment variable, for example `POSTGRES_VERSION=17` (the `stephaneklein/pg_back-docker-sidecar` Docker image supports PostgreSQL versions `15`, `16`, and `17`).
+
 ```
 services:
   postgres1:
@@ -47,6 +49,7 @@ services:
     image: stephaneklein/pg_back-docker-sidecar:sklein-fork
     restart: no
     environment:
+      POSTGRES_VERSION: 17
       POSTGRES_HOST: postgres1
       POSTGRES_PORT: 5432
       POSTGRES_USER: postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,7 @@ services:
     image: stephaneklein/pg_back-docker-sidecar:sklein-fork
     restart: no
     environment:
+      POSTGRES_VERSION: 17
       POSTGRES_HOST: postgres1
       POSTGRES_PORT: 5432
       POSTGRES_USER: postgres
@@ -92,6 +93,7 @@ services:
     restart: no
     environment:
       DISABLE_CRON: "true"
+      POSTGRES_VERSION: 17
       POSTGRES_HOST: postgres2
       POSTGRES_PORT: 5432
       POSTGRES_USER: postgres

--- a/pg_back.conf.tmpl
+++ b/pg_back.conf.tmpl
@@ -2,7 +2,7 @@
 # Reference: https://github.com/orgrim/pg_back/blob/04efb95fda74c8efc4818f86e2da8b5ac877a962/pg_back.conf
 
 # PostgreSQL binaries path. Leave empty to search $PATH
-bin_directory =
+bin_directory = /usr/libexec/postgresql{{ getenv "POSTGRES_VERSION" "17" }}/
 
 # Where to store the dumps and other files. It can include the
 # {dbname} keyword that will be replaced by the name of the database


### PR DESCRIPTION
Close #10 

Add support for PostgreSQL versions 15, 16 and 17.

PostgreSQL version can be configured with POSTGRES_VERSION.

Reference: https://github.com/stephane-klein/pg_back-docker-sidecar/issues/10