### PR TITLE
Use officiel pg_back repository

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -27,11 +27,7 @@ jobs:
         run: |
           DATETIME=$(date '+%Y%m%d%H%M%S')
           SHORT_SHA=$(git rev-parse --short HEAD)
-          echo "docker_tag=${DATETIME}-${SHORT_SHA}-sklein-fork" >> $GITHUB_OUTPUT
-
-      # `sklein-fork` contains the code from the following branch https://github.com/stephane-klein/pg_back/commits/sklein-main/
-      # when this Pull Request will be merged https://github.com/orgrim/pg_back/pull/147
-      # `sklein-fork` will be replaced by `pg_back2.5.0`
+          echo "docker_tag=${DATETIME}-${SHORT_SHA}-pg_back5375ec2" >> $GITHUB_OUTPUT
 
       - name: Build and Push Docker Image
         uses: docker/build-push-action@v6

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -19,11 +19,7 @@ jobs:
         run: |
           DATETIME=$(date '+%Y%m%d%H%M%S')
           SHORT_SHA=$(git rev-parse --short HEAD)
-          echo "docker_tag=${DATETIME}-${SHORT_SHA}-sklein-fork" >> $GITHUB_OUTPUT
-
-      # `sklein-fork` contains the code from the following branch https://github.com/stephane-klein/pg_back/commits/sklein-main/
-      # when this Pull Request will be merged https://github.com/orgrim/pg_back/pull/147
-      # `sklein-fork` will be replaced by `pg_back2.5.0`
+          echo "docker_tag=${DATETIME}-${SHORT_SHA}-pg_back5375ec2" >> $GITHUB_OUTPUT
 
       - name: Build and Push Docker Image
         uses: docker/build-push-action@v6

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,14 +10,15 @@ ARG TARGETARCH
 ARG SUPERCRONIC_VERSION=0.2.33
 
 RUN apk add --no-cache git zip curl \
-    # Install supercronic
-    && curl -fsSLO "https://github.com/aptible/supercronic/releases/download/v${SUPERCRONIC_VERSION}/supercronic-${TARGETOS}-${TARGETARCH}" \
-    && mv "supercronic-${TARGETOS}-${TARGETARCH}" "/tmp/supercronic"
+# Install supercronic
+&& curl -fsSLO "https://github.com/aptible/supercronic/releases/download/v${SUPERCRONIC_VERSION}/supercronic-${TARGETOS}-${TARGETARCH}" \
+&& mv "supercronic-${TARGETOS}-${TARGETARCH}" "/tmp/supercronic"
 
 WORKDIR /go
 
-RUN git clone --depth 1 --branch sklein-main https://github.com/stephane-klein/pg_back.git
-RUN cd pg_back && CGO_ENABLED=0 go build -ldflags="-w -s" -o /go/bin/pg_back
+
+RUN git clone --branch master https://github.com/orgrim/pg_back.git
+RUN cd pg_back && git checkout 5375ec26a6e8453ec843e31ed116c6b35774e3a9 && CGO_ENABLED=0 go build -ldflags="-w -s" -o /go/bin/pg_back
 
 FROM --platform=$BUILDPLATFORM alpine:3.21
 

--- a/README.md
+++ b/README.md
@@ -4,20 +4,11 @@ Initially, in this repository I wanted to test the implementation of [pg_back](h
 
 And gradually, I changed the objective of this project. Now it contains
 
-- source code to build a Docker Sidecar image named [`stephaneklein/pg_back-docker-sidecar:sklein-fork`](https://hub.docker.com/repository/docker/stephaneklein/pg_back-docker-sidecar/general)
+- source code to build a Docker Sidecar image named [`stephaneklein/pg_back-docker-sidecar`](https://hub.docker.com/repository/docker/stephaneklein/pg_back-docker-sidecar/general)
 - a step-by-step tutorial that presents all aspects of using this container
 - a workspace that allows me to contribute to the upstream `pg_back` project: [`./src/`](./src/)
 
 For more context, see the following note written in French: https://notes.sklein.xyz/Projet%2027/
-
-## What is `pg_back-docker-sidecar:sklein-fork` Docker image?
-
-The `pg_back-docker-sidecar` project uses the [`stephaneklein/pg_back-docker-sidecar:sklein-fork`](https://hub.docker.com/repository/docker/stephaneklein/pg_back-docker-sidecar/general) Docker image
-which contains a build from the [`sklein-main`](https://github.com/stephane-klein/pg_back/tree/sklein-main) branch ([check the history to see what has been integrated](https://github.com/stephane-klein/pg_back/commits/sklein-main/)).
-
-Why use this branch? To benefit immediately from [several Pull Requests pending merge](https://github.com/orgrim/pg_back/pulls).
-
-To build this image, see the section [Build stephaneklein/pg_back:wip with custom pg_back](https://github.com/stephane-klein/pg_back-docker-sidecar/tree/main/src#build-stephanekleinpg_backwip-with-custom-pg_back)
 
 ## How to use pg_back Docker Sidecar in production?
 
@@ -46,7 +37,7 @@ services:
       start_period: 30s
 
   pg_back:
-    image: stephaneklein/pg_back-docker-sidecar:sklein-fork
+    image: stephaneklein/pg_back-docker-sidecar
     restart: no
     environment:
       POSTGRES_VERSION: 17

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,7 @@ services:
 
   pg_back1:
     build: .
-    image: stephaneklein/pg_back-docker-sidecar:sklein-fork
+    image: stephaneklein/pg_back-docker-sidecar
     restart: no
     environment:
       POSTGRES_VERSION: 17
@@ -89,7 +89,7 @@ services:
 
   pg_back2:
     build: .
-    image: stephaneklein/pg_back-docker-sidecar:sklein-fork
+    image: stephaneklein/pg_back-docker-sidecar
     restart: no
     environment:
       DISABLE_CRON: "true"

--- a/pg_back.conf.tmpl
+++ b/pg_back.conf.tmpl
@@ -45,9 +45,9 @@ with_templates = {{ getenv "WITH_TEMPLATES" "" }}
 # Dump only databases, excluding configuration and globals
 dump_only = {{ getenv "DUMP_ONLY" "false" }}
 
-# Apply a single consistent timestamp to all filenames in a snapshot
-# instead of using individual file creation times
-uniform_snapshot_timestamp = true
+# Apply the same consistent timestamp to all filenames generated
+# by pg_back instead of using individual file creation times
+uniform_timestamp = true
 
 # Format of the dump, understood by pg_dump. Possible values are
 # plain, custom, tar or directory.

--- a/scripts/docker-push.sh
+++ b/scripts/docker-push.sh
@@ -3,4 +3,4 @@ set -e
 
 cd "$(dirname "$0")/../"
 
-docker push stephaneklein/pg_back-docker-sidecar:sklein-fork
+docker push stephaneklein/pg_back-docker-sidecar:latest

--- a/src/README.md
+++ b/src/README.md
@@ -63,7 +63,7 @@ Everything worked well.
 Here is a method to build a Docker image `stephaneklein/pg_back:wip` incorporating the `./github.com/orgrim/pg_back/pg_back` binary.
 
 ```sh
-$ docker build -f ../Dockerfile.dev ../ -t stephaneklein/pg_back-docker-sidecar:sklein-fork
-$ docker run --rm -it stephaneklein/pg_back-docker-sidecar:sklein-fork --version
+$ docker build -f ../Dockerfile.dev ../ -t stephaneklein/pg_back-docker-sidecar
+$ docker run --rm -it stephaneklein/pg_back-docker-sidecar --version
 pg_back version 2.6.0
 ```


### PR DESCRIPTION
Now that https://github.com/orgrim/pg_back/pull/147#issuecomment-3007850421 has been merged, the pg_back fork used in the repository is no longer relevant.

The purpose of this merge request is to replace the fork with the upstream version.